### PR TITLE
Implementation for Parallelism

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current Example Init File",
+            "python": "${workspaceFolder}/examples/.venv/Scripts/python.exe",
+            "cwd": "${workspaceFolder}/examples",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/examples/parallelism/__init__.py
+++ b/examples/parallelism/__init__.py
@@ -1,0 +1,49 @@
+import time
+from engine import Task, register, PipelineExecutor
+
+@register()
+class FirstWaveTask(Task):
+    def perform_task(self):
+        print_task_start(self)
+        time.sleep(2)
+        print_task_end(self)
+
+@register(depends_on=FirstWaveTask)
+class SecondWaveTaskOne(Task):
+    def perform_task(self):
+        print_task_start(self)
+        time.sleep(4)
+        print_task_end(self)
+
+@register(depends_on=FirstWaveTask)
+class SecondWaveTaskTwo(Task):
+    def perform_task(self):
+        print_task_start(self)
+        time.sleep(2)
+        print_task_end(self)
+
+@register(depends_on=SecondWaveTaskOne)
+class ThirdWaveTaskOne(Task):
+    def perform_task(self):
+        print_task_start(self)
+        time.sleep(1)
+        print_task_end(self)
+
+@register(depends_on=SecondWaveTaskTwo)
+class ThirdWaveTaskTwo(Task):
+    def perform_task(self):
+        print_task_start(self)
+        time.sleep(1)
+        print_task_end(self)
+
+def print_task_start(task: Task):
+    print('Starting ' + type(task).__name__)
+
+def print_task_end(task: Task):
+    print('Finished ' + type(task).__name__)
+
+if __name__ == "__main__":
+    executor = PipelineExecutor()
+    starting_tasks = executor.get_independent_starting_tasks()
+    # executor.run_with_thread_pool_executors(starting_tasks)
+    executor.run_with_thread_pool_executors_v2(starting_tasks)

--- a/src/engine/pipeline_executor.py
+++ b/src/engine/pipeline_executor.py
@@ -2,16 +2,30 @@ from collections import defaultdict, deque
 from typing import Dict
 
 from engine.config_provider import get_default_config_provider
+from engine.task_tracker import TaskTracker
 from reporters import plan_reporters
+
+import concurrent.futures
 
 
 tasks_registry = {}
-tasks_dependencies = defaultdict(list)
+tasks_dependencies = defaultdict(list[str])
 context: Dict = dict()
 
 config_provider = get_default_config_provider()
 context.update(config_provider.get_config())
 
+def run_with_thread_pool_executor(taskTracker: TaskTracker):
+    taskTracker.task.perform_task()
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = {executor.submit(run_with_thread_pool_executor, tracker): tracker for tracker in taskTracker.dependentTrackers}
+        concurrent.futures.as_completed(futures)
+
+def run_task(taskTracker: TaskTracker) -> list[TaskTracker]:
+    taskTracker.task.perform_task()
+
+    return taskTracker.dependentTrackers
 
 class PipelineExecutor:
     def __init__(self):
@@ -45,9 +59,26 @@ class PipelineExecutor:
 
         if len(execution_order) != len(self.tasks):
             raise Exception("Circular dependency detected")
-
+        
         return execution_order
+    
+    def get_independent_starting_tasks(self):
+        task_trackers: dict[str, TaskTracker] = {task_name: TaskTracker(task) for task_name, task in self.tasks.items()}
+        for task_name, dependency_names in self.dependencies.items():
+            dependent_task_tracker = task_trackers[task_name]
+            for dependency_name in dependency_names:
+                prerequisite_task_tracker = task_trackers[dependency_name]
+                prerequisite_task_tracker.dependentTrackers.append(dependent_task_tracker)
+                dependent_task_tracker.prerequisiteTracker = prerequisite_task_tracker
 
+        independent_tasks = [task_tracker 
+                        for task_tracker in task_trackers.values() 
+                        if task_tracker.prerequisiteTracker is None]
+
+        # TODO check for circular deps
+
+        return independent_tasks
+    
     def report_plan(self):
         for reporter in plan_reporters:
             reporter.report(self.execution_order)
@@ -58,6 +89,28 @@ class PipelineExecutor:
             print(f"Executing {task_name}")
             task.perform_task()
 
+    def run_with_thread_pool_executors(self, starting_task_trackers: list[TaskTracker]):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = {executor.submit(run_with_thread_pool_executor, tracker): tracker for tracker in starting_task_trackers}
+            concurrent.futures.as_completed(futures)
+
+    # This is probably the better implementation
+    # Only uses one thread pool executor, so prevents potentially exponential increase
+    # in number of thread pool executors used.
+    # Adapted from https://stackoverflow.com/a/51883938
+    def run_with_thread_pool_executors_v2(self, starting_task_trackers: list[TaskTracker]):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [executor.submit(run_task, tracker) for tracker in starting_task_trackers]
+
+            while futures:
+                # As mentioned in stack overflow article,
+                # This for loop continues when one of the "future" objects
+                # completes, not after all of them have.
+                for future in concurrent.futures.as_completed(futures):
+                    futures.remove(future)
+
+                    for taskDependency in future.result():
+                        futures.append(executor.submit(run_task, taskDependency))
 
 def register(depends_on=None):
     """Decorator to register a task class in the tasks registry"""

--- a/src/engine/task_tracker.py
+++ b/src/engine/task_tracker.py
@@ -1,0 +1,7 @@
+from engine.task import Task
+
+class TaskTracker:
+    def __init__(self, task: Task):
+        self.task: Task = task
+        self.prerequisiteTracker: TaskTracker = None
+        self.dependentTrackers: list[TaskTracker] = []


### PR DESCRIPTION
Added ability to execute tasks in parallel. Started using node-based data structures to do this partly because I wasn't sure about how thread safety might work when modifying lists, but after having finished this it may have been OK to use lists of tasks as long as they were on the main thread. But I also wanted a way to efficiently navigate through task dependencies from the starting task through all its dependents and the node structure seemed to work well for that.

After the data structure was finished I started trying to use ThreadPoolExecutor. My first try at this worked but I don't think it was a good design. It created another thread pool executor for each node and almost certainly wouldn't scale well. v2 seems to work well though and I think it should scale much better! It only uses one ThreadPoolExecutor.

I also added a launch.json file that runs your currently open python file using the virtual environment from the `examples` directory. It sets the current working directory to the examples directory as well. This is good for executing example `__init__.py` files.

Feel free to take and leave what you'd like!